### PR TITLE
Create app configuration

### DIFF
--- a/lazynx/internal/cli/root.go
+++ b/lazynx/internal/cli/root.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/charmbracelet/huh"
+	"github.com/lazyengs/lazynx/internal/config"
 	"github.com/lazyengs/lazynx/internal/logs"
 	"github.com/lazyengs/lazynx/internal/nxls"
 	"github.com/lazyengs/lazynx/internal/tui"
@@ -15,7 +16,6 @@ import (
 
 var (
 	verbose bool
-	logFile string
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -32,19 +32,12 @@ to enter the workspace path with validation to ensure it contains nx.json.`,
 
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
-	rootCmd.PersistentFlags().StringVar(&logFile, "log-file", "", "Specify custom log file path")
 }
 
 func runLazyNX(cmd *cobra.Command, args []string) error {
-	// Setup logging
-	var logPath string
-	if logFile != "" {
-		logPath = logFile
-	} else {
-		logPath = logs.GetDefaultLogFile()
-	}
+	config := config.LoadConfiguration()
 
-	logger, err := logs.SetupFileLogger(logPath, verbose)
+	logger, err := logs.SetupFileLogger(config.LogsPath, verbose)
 	if err != nil {
 		return fmt.Errorf("error setting up logger: %w", err)
 	}
@@ -65,7 +58,7 @@ func runLazyNX(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create nxlsclient but don't initialize it yet
-	client := nxls.CreateNxlsclient(logger)
+	client := nxls.CreateNxlsclient(logger, config)
 
 	// Create and run the program
 	p := tui.Create(client, logger, workspacePath)

--- a/lazynx/internal/config/config.go
+++ b/lazynx/internal/config/config.go
@@ -1,0 +1,87 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+const (
+	AppName    = ".lazynx"
+	ConfigName = "lazynx.json"
+)
+
+type Config struct {
+	Theme    string `json:"theme"`
+	LogsPath string `json:"logs"`
+}
+
+func new() *Config {
+	return &Config{
+		Theme:    "default",
+		LogsPath: getDefaultLogFile(),
+	}
+}
+
+func LoadConfiguration() *Config {
+	config := new()
+
+	homeDir, err := getHomeDir()
+	if err != nil {
+		return config
+	}
+
+	globalConfigPath := filepath.Join(homeDir, AppName, ConfigName)
+	if globalConfig, eC := loadConfigFromFile(globalConfigPath); eC == nil {
+		config = config.overrideWith(globalConfig)
+	}
+
+	return config
+}
+
+func loadConfigFromFile(configPath string) (*Config, error) {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var config Config
+	if err := json.Unmarshal(data, &config); err != nil {
+		return nil, err
+	}
+
+	return &config, nil
+}
+
+func (c *Config) overrideWith(target *Config) *Config {
+	result := *c
+
+	if target != nil {
+		if target.Theme != "" {
+			result.Theme = target.Theme
+		}
+		if target.LogsPath != "" {
+			result.LogsPath = target.LogsPath
+		}
+	}
+
+	return &result
+}
+
+func getHomeDir() (string, error) {
+	if dir := os.Getenv("XDG_CONFIG_HOME"); dir != "" {
+		return dir, nil
+	}
+
+	if dir, err := os.UserHomeDir(); err == nil {
+		return dir, nil
+	}
+
+	return "", errors.New("unable to determine user config directory")
+}
+
+func getDefaultLogFile() string {
+	homeDir, _ := os.UserHomeDir()
+	return filepath.Join(homeDir, AppName, "logs", "lazynx.log")
+}

--- a/lazynx/internal/config/config.go
+++ b/lazynx/internal/config/config.go
@@ -13,13 +13,11 @@ const (
 )
 
 type Config struct {
-	Theme    string `json:"theme"`
 	LogsPath string `json:"logs"`
 }
 
 func new() *Config {
 	return &Config{
-		Theme:    "default",
 		LogsPath: getDefaultLogFile(),
 	}
 }
@@ -58,9 +56,6 @@ func (c *Config) overrideWith(target *Config) *Config {
 	result := *c
 
 	if target != nil {
-		if target.Theme != "" {
-			result.Theme = target.Theme
-		}
 		if target.LogsPath != "" {
 			result.LogsPath = target.LogsPath
 		}

--- a/lazynx/internal/logs/logger.go
+++ b/lazynx/internal/logs/logger.go
@@ -47,9 +47,3 @@ func SetupFileLogger(logFile string, verbose bool) (*zap.SugaredLogger, error) {
 	logger := zap.New(core, zap.AddCaller())
 	return logger.Sugar(), nil
 }
-
-// GetDefaultLogFile returns the default log file path for lazynx
-func GetDefaultLogFile() string {
-	homeDir, _ := os.UserHomeDir()
-	return filepath.Join(homeDir, ".lazynx", "logs", "lazynx.log")
-}

--- a/lazynx/internal/nxls/nxlsclient.go
+++ b/lazynx/internal/nxls/nxlsclient.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	tea "github.com/charmbracelet/bubbletea/v2"
+	"github.com/lazyengs/lazynx/internal/config"
 	"github.com/lazyengs/lazynx/internal/logs"
 	"github.com/lazyengs/lazynx/pkg/nxlsclient"
 	"github.com/lazyengs/lazynx/pkg/nxlsclient/commands"
@@ -13,9 +14,9 @@ import (
 	"go.uber.org/zap"
 )
 
-func CreateNxlsclient(logger *zap.SugaredLogger) *nxlsclient.Client {
+func CreateNxlsclient(logger *zap.SugaredLogger, config *config.Config) *nxlsclient.Client {
 	// Setup separate logger for nxlsclient
-	nxlsclientLogFile := filepath.Join(filepath.Dir(logs.GetDefaultLogFile()), "nxlsclient.log")
+	nxlsclientLogFile := filepath.Join(filepath.Dir(config.LogsPath), "nxlsclient.log")
 	nxlsclientLogger, err := logs.SetupFileLogger(nxlsclientLogFile, true)
 	if err != nil {
 		logger.Errorw("Failed to setup nxlsclient logger, using main logger", "error", err)


### PR DESCRIPTION
## Summary

This introduces the ability to load app configuration from `HOMEDIR/.lazynx/lazynx.json` file. At the moment can be used to define logs file directory.

## Related Issue

Related to #15

## Type

<!-- What type of change is this? -->

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Other: <!-- specify -->

## Testing

I added a global configuration with `.lazynx.json` specifying some logs path and was able to load the config and write the logs properly for both the _TUI_ and the _NXClient_

## Additional Notes

**Workspace Configuration**

Ideally should support load configuration from the workspace path. In order to do this, there are some considerations related to the logs when prompt workspace path, those will need to be removed or change the way are written since we need the workspace path before creating the configuration type so all the logs in the process can't be written.
